### PR TITLE
Add environment override for database config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,35 @@ tables:
 - "example_table"
 ```
 
+##### Database
+
+Database configuration happens in your normal `config/database.yml`. If you want
+a database configuration that is NOT tied to your Rails environment, you can run
+these tasks with `SNAPSHOT_ENV` set, and that will override where in the
+`config/database.yml` it looks. For example:
+
+
+With this config file:
+
+```yml
+# config/database.yml
+production:
+  username: root
+  password: secret
+
+snapshot:
+  username: readonly
+  password: secret
+```
+
+Running the below:
+
+```
+SNAPSHOT_ENV=snapshot bundle exec rake db:snapshot:create
+```
+
+It will use `readonly` instead of the `root` user.
+
 ### Tasks
 
 ##### `db:snapshot:create`

--- a/lib/active_record/snapshot/configuration.rb
+++ b/lib/active_record/snapshot/configuration.rb
@@ -52,7 +52,11 @@ module ActiveRecord
       include Hashie::Extensions::Dash::Coercion
       include Hashie::Extensions::Dash::IndifferentAccess
 
-      property :db, default: ->(_) { ::Rails.application.config.database_configuration[Rails.env] }, coerce: DBConfig
+      def self.env
+        ENV.fetch("SNAPSHOT_ENV", Rails.env)
+      end
+
+      property :db, default: ->(_) { ::Rails.application.config.database_configuration[env] }, coerce: DBConfig
       property :s3, required: true, coerce: S3Config
       property :ssl_key, required: true
       property :tables, required: true

--- a/lib/active_record/snapshot/version.rb
+++ b/lib/active_record/snapshot/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module Snapshot
-    VERSION = '0.2.1'
+    VERSION = '0.3.0'
   end
 end

--- a/test/active_record/snapshot/configuration_test.rb
+++ b/test/active_record/snapshot/configuration_test.rb
@@ -7,6 +7,23 @@ module ActiveRecord::Snapshot
 
     subject { ActiveRecord::Snapshot.config }
 
+    describe "::env" do
+      describe "when the SNAPSHOT_ENV is set" do
+        let(:env) { "foo" }
+        before { ENV.stubs(fetch: env) }
+
+        it "returns the SNAPSHOT_ENV" do
+          assert_equal env, subject.class.env
+        end
+      end
+
+      describe "when SNAPSHOT_ENV is not set" do
+        it "returns the Rails environment" do
+          assert_equal Rails.env, subject.class.env
+        end
+      end
+    end
+
     describe "#db" do
       it "responds to the appropriate methods" do
         {


### PR DESCRIPTION
This allows us to have a non-rails-env database configuration in production (see [here](https://github.com/coverhound/activerecord-snapshot/blob/4614b01b56b0f220481288ff146e3fbb0c11aad8/README.md#database))