### PR TITLE
Get latest info before creating new snapshot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activerecord-snapshot (0.3.3)
+    activerecord-snapshot (0.3.4)
       fog-aws (>= 0.1.2)
       hashie (>= 3.4.3)
       railties (>= 4.1.0, < 6.0)

--- a/lib/active_record/snapshot/files/version.rb
+++ b/lib/active_record/snapshot/files/version.rb
@@ -20,8 +20,12 @@ module ActiveRecord
           File.write(path, version)
         end
 
+        def download
+          s3.download_to(path)
+        end
+
         def upload
-          S3.new(directory: config.s3.paths.snapshots).upload(path)
+          s3.upload(path)
         end
 
         def filename
@@ -33,6 +37,10 @@ module ActiveRecord
         end
 
         private
+
+        def s3
+          S3.new(directory: config.s3.paths.snapshots)
+        end
 
         def config
           ActiveRecord::Snapshot.config

--- a/lib/active_record/snapshot/version.rb
+++ b/lib/active_record/snapshot/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module Snapshot
-    VERSION = '0.3.3'
+    VERSION = '0.3.4'
   end
 end

--- a/lib/tasks/active_record/snapshot_tasks.rake
+++ b/lib/tasks/active_record/snapshot_tasks.rake
@@ -3,6 +3,8 @@ namespace :db do
     desc "Create a snapshot of the current database and store it in S3"
     task create: :load do
       abort "Meant for production only!" unless Rails.env.production?
+      ActiveRecord::Snapshot::List.download
+      ActiveRecord::Snapshot::Version.download
       ActiveRecord::Snapshot::Create.call
     end
 

--- a/test/active_record/snapshot/rake_test.rb
+++ b/test/active_record/snapshot/rake_test.rb
@@ -27,6 +27,8 @@ module ActiveRecord::Snapshot
 
       it "runs in production" do
         Rails.env.expects(production?: true).once
+        ActiveRecord::Snapshot::Version.expects(:download).once
+        ActiveRecord::Snapshot::List.expects(:download).once
         ActiveRecord::Snapshot::Create.expects(:call).once
         task.invoke
       end


### PR DESCRIPTION
Snapshots before relied on having an existing List and Version file.
This would mean caching in between capistrano releases - and also that
if we had snapshots on different machines that they would fail.

This makes it so they always get the latest file from S3