### PR TITLE
forced openssl to use md5, which is not standard in versions > 1.0.1

### DIFF
--- a/lib/active_record/snapshot/commands/openssl.rb
+++ b/lib/active_record/snapshot/commands/openssl.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     class OpenSSL
       def self.encrypt(input:, output:)
         system(<<-SH)
-        nice openssl aes-256-cbc \\
+        nice openssl aes-256-cbc -md md5 \\
           -in #{input} \\
           -out #{output} \\
           -kfile #{ActiveRecord::Snapshot.config.ssl_key}
@@ -12,7 +12,7 @@ module ActiveRecord
 
       def self.decrypt(input:, output:)
         system(<<-SH)
-        nice openssl enc -d -aes-256-cbc \\
+        nice openssl enc -d -aes-256-cbc -md md5 \\
           -in #{input} \\
           -out #{output} \\
           -kfile #{ActiveRecord::Snapshot.config.ssl_key}


### PR DESCRIPTION
This force md5 on both encryption and decryption. This solves an issue where newer ubuntu instances running openssl 1.0.1 were forcing sha256. md5 should still work fine for this application, and changing it to sha256 would affect our ability to read older snapshots without building some backwards compatibility into the code. 