### PR TITLE
Added a conditional for running the set_env step 

### DIFF
--- a/lib/active_record/snapshot/actions/import.rb
+++ b/lib/active_record/snapshot/actions/import.rb
@@ -52,7 +52,8 @@ module ActiveRecord
 
         steps[:import] = "Importing the snapshot into #{config.db.database}"
         steps[:save] = "Caching the new snapshot version" unless named_version? || tables.present?
-        steps[:set_env] = "Setting database environment to #{Rails.env}"
+        steps[:set_env] = "Setting database environment to #{Rails.env}" if Rails::VERSION::MAJOR >= 5
+
         steps
       end
 

--- a/lib/active_record/snapshot/version.rb
+++ b/lib/active_record/snapshot/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module Snapshot
-    VERSION = '0.4.0'
+    VERSION = '0.5.0'
   end
 end


### PR DESCRIPTION
As referenced in @swapdisc 's comment on #12, this did step did cause an ugly output error in personal lines. We were forced to upgrade the gem due to the ubuntu 18 changes, and therefore had to release #12 to personal lines. Adding this conditional prevents this from running in the case that rails <5 is used. 