### PR TITLE
Disable gtid on mysqldumps

### DIFF
--- a/lib/active_record/snapshot/commands/mysql.rb
+++ b/lib/active_record/snapshot/commands/mysql.rb
@@ -8,8 +8,8 @@ module ActiveRecord
       end
 
       def dump(tables:, output:)
-        dump_command("--no-data #{database} > #{output}") &&
-          dump_command("--quick #{database} #{tables.join(" ")} >> #{output}")
+        dump_command("--no-data --set-gtid-purged=OFF #{database} > #{output}") &&
+          dump_command("--quick --set-gtid-purged=OFF #{database} #{tables.join(" ")} >> #{output}")
       end
 
       def self.import(*args)

--- a/lib/active_record/snapshot/version.rb
+++ b/lib/active_record/snapshot/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module Snapshot
-    VERSION = '0.6.1.jcprepermissions.1'
+    VERSION = '0.7.0'
   end
 end

--- a/lib/active_record/snapshot/version.rb
+++ b/lib/active_record/snapshot/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module Snapshot
-    VERSION = '0.6.0'
+    VERSION = '0.6.1.jcprepermissions.1'
   end
 end


### PR DESCRIPTION
The default gtid setting mysql versions 5.7.23 or for a partial dump
will "include the GTIDs of all transactions, even those that changed
suppressed parts of the database."

And importing those snapshots can break depending on db user permissions caused by "SET @@SESSION.SQL_LOG_BIN" lines in the dump file.

Explicitly set set-gtid-purged flag during mysqldump command to not
restore GTIDs and omit those dumpfile lines, allowing imports

ref:
https://help.poralix.com/articles/mysql-access-denied-you-need-the-super-privilege-for-this-operation
https://medium.com/searce/mysql-adventures-gtid-replication-in-aws-rds-508abd87780a
https://dev.mysql.com/doc/refman/5.7/en/replication-mode-change-online-enable-gtids.html
https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-failover.html